### PR TITLE
Add some `*.google` domains and other misc domains 

### DIFF
--- a/pihole-google.txt
+++ b/pihole-google.txt
@@ -530,6 +530,7 @@ ccacc69a0d7467ebaac293677146be75.safeframe.googlesyndication.com
 cdff40dad0a98d6b641bfca1a05423a8.safeframe.googlesyndication.com
 chat.google.com
 chrome.google.com
+chromeenterprise.google
 cimsun.google.com
 classroom.google.com
 client1.google.com
@@ -831,10 +832,13 @@ google.vu
 google.ws
 googleadservices.com
 googleanalytics.com
+googleapis.co
 googleapps.com
 googlearth.com
 googleblog.com
 googlebot.com
+googlecdn.org
+googlecloudpresscorner.com
 googlecode.com
 googlecommerce.com
 googledrive.com
@@ -843,6 +847,7 @@ googleearth.com
 googlegroups.com
 googlehosts.org
 googlemaps.com
+googlemerchandisestore.com
 googlepagecreator.com
 googlescholar.com
 googlesyndication-cn.com
@@ -999,6 +1004,7 @@ realtime.google.com
 redirector.c.googlesyndication.com
 registry.google.com
 relay.google.com
+research.google
 research.google.com
 rooms.google.com
 s0.2mdn.net
@@ -1026,6 +1032,8 @@ ss-3.googlehosts.org
 static.2mdn.net
 station.google.com
 store.google.com
+stories.google
+sre.google
 support.google.com
 survey.google.com
 surveys.google.com
@@ -1045,6 +1053,7 @@ transit.google.com
 translate.google.com
 travel.google.com
 tv.google.com
+tv.google
 twx.2mdn.net
 uol.google.com
 upload.google.com
@@ -3207,6 +3216,7 @@ oncall.corp.google.com
 onetoday.google.com
 onka64mqbc.com
 opensource.google.com
+opensource.google
 optimize.google.com
 orderfood.google.com
 orkut.google.com

--- a/pihole-google.txt
+++ b/pihole-google.txt
@@ -639,6 +639,7 @@ google.ba
 google.be
 google.bf
 google.bg
+google.bh
 google.bi
 google.bj
 google.bs
@@ -793,6 +794,7 @@ google.mv
 google.mw
 google.ne
 google.net
+google.ng
 google.nl
 google.no
 google.nr
@@ -1080,6 +1082,7 @@ www.google.ba
 www.google.be
 www.google.bf
 www.google.bg
+www.google.bh
 www.google.bi
 www.google.bj
 www.google.bs
@@ -1207,6 +1210,7 @@ www.google.im
 www.google.iq
 www.google.is
 www.google.it
+www.google.it.ao
 www.google.je
 www.google.jo
 www.google.kg


### PR DESCRIPTION
Added the following domains:
- `chromeenterprise.google`
- `googleapis.co`
- `googlecdn.org`
- `googlecloudpresscorner.com`
- `googlemerchandisestore.com`
- `research.google`
- `stories.google`
- `sre.google`
- `tv.google`
- `opensource.google`