### PR TITLE
fix: NextDNS markdown url by using anchor tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ and then, executing it. It should add all of the above regex automatically.
 ## FAQ
 
 <details>
-  <summary>Can I use it with [NextDNS](https://nextdns.io/)?</summary>
+  <summary>Can I use it with <a href="https://nextdns.io">NextDNS</a>?</summary>
   <p>Yep ! It is available in their selection of domains list, labeled as ¨No Google¨. NextDNS is using the wildcard-domains format, so you will have to manually whitelist some specific services, as it will block everything Google related.</p>
 </details>
 


### PR DESCRIPTION
This was previously used in the README markdown

```markdown
<details>
    ....
    [NextDNS](https://nextdns.io)
    ....
</details>
```

However using markdown hyperlinking inside html tag doesn't work and can be solved by using anchor tags.
