### PR TITLE
Remove unnecessary sudo from regex install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ NOTE: Youtube advertisements are pretty difficult to block trough DNS, as they m
 You can also easily use the modified [pihole regex installer script](https://github.com/mmotti/pihole-regex) by [@mmoti](https://github.com/mmotti) by executing this terminal command from your raspberry Pi Pi-hole server.
 
 ```
-curl -sSl https://raw.githubusercontent.com/nickspaargaren/no-google/master/install.py | sudo python3
+curl -sSl https://raw.githubusercontent.com/nickspaargaren/no-google/master/install.py | python3
 
 ```
 


### PR DESCRIPTION
## Context
Turns out the sudo command isn't necessary here. This PR removes this from the readme.

https://github.com/nickspaargaren/no-google/issues/207

## How to test

### Requirements

-  Docker

### Setup new Pi-Hole test installation

- Pull the Pi-hole docker image by running `docker pull pihole/pihole:2024.07.0`
- Start the Pi-hole docker container by running `docker run --name pihole -d -p 8080:80 -e WEBPASSWORD=admin pihole/pihole:2024.07.0`
- Navigate to http://localhost:8080/admin/
- Login in with password `admin` and check "Remind me for 7 days"
- Install Python inside the docker container by running `docker exec pihole sh -c "sudo apt update && apt install python3 -y"`

### Import domains in Pi-Hole

- Navigate to http://localhost:8080/admin/groups-domains.php and make sure there are no rules 
- Import a custom list by running `docker exec pihole sh -c "curl -sSl https://raw.githubusercontent.com/nickspaargaren/no-google/master/install.py | python3"`
- Refresh or navigate to http://localhost:8080/admin/groups-domains.php and make sure the domains are still imported correctly without `sudo`

