### PR TITLE
Update Python to v3.9

### DIFF
--- a/.github/workflows/automated-updates.yml
+++ b/.github/workflows/automated-updates.yml
@@ -16,7 +16,7 @@ jobs:
         git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
         cache: 'pip'
     - name: Update categories
       run: |

--- a/.github/workflows/dns-check.yml
+++ b/.github/workflows/dns-check.yml
@@ -15,7 +15,7 @@ jobs:
         name: Python setup
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
           cache: 'pip'
       - name: Install Requirements
         run: pip install -r requirements.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,8 @@ jobs:
       with:
         python-version: 3.9
         cache: 'pip'
-    - run: pip install -r requirements.txt
+    - name: Install Requirements
+      run: pip install -r requirements.txt
     - name: Check if list includes regex domains
       run: |
         cd scripts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
         cache: 'pip'
     - run: pip install -r requirements.txt
     - name: Check
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
         cache: 'pip'
     - run: pip install -r requirements.txt
     - name: Check for duplicate lines
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
         cache: 'pip'
     - run: pip install -r requirements.txt
     - name: Check if list includes regex domains


### PR DESCRIPTION
This PR updates our project from Python 3.8 to Python 3.9, in response to Python 3.8 reaching its official end of life as of October 7, 2024. By upgrading to Python 3.9, we ensure our project remains secure, maintainable, and compatible with future dependencies.