### PR TITLE
Remove papy.co.jp

### DIFF
--- a/pihole-google.txt
+++ b/pihole-google.txt
@@ -1546,7 +1546,6 @@ opt.google.com
 pack.google.com
 pagead2.googlesyndication.com
 pagead46.googlesyndication.com
-papy.co.jp
 partnerplustoolkit.com
 partners-aunz.com
 partners.google.com


### PR DESCRIPTION
[Not a Google domain: https://whois.domaintools.com/papy.co.jp](https://whois.domaintools.com/papy.co.jp)