### PR TITLE
Set username field in Unbound config

### DIFF
--- a/unbound.conf
+++ b/unbound.conf
@@ -2,4 +2,5 @@
 # Used primarily to check pihole-google-unbound.conf for errors
 
 server:
+  username: ""
   include: "pihole-google-unbound.conf"


### PR DESCRIPTION
## Summary

Add the `username` directive to `unbound.conf`.

## Changes

- Set `username: ""` in `unbound.conf` to explicitly define the user context for Unbound

## Motivation

Without an explicit `username` field, Unbound may default to a system user or produce warnings depending on the platform/configuration. Setting it to an empty string ensures consistent, predictable behavior.