### PR TITLE
fix(regex): match google.com and subdomains with any TLD in pattern 1

### DIFF
--- a/regex.list
+++ b/regex.list
@@ -1,4 +1,4 @@
-(.*\.|^)((think)?with)?google($|((adservices|apis|mail|static|syndication|tagmanager|tagservices|usercontent|zip|-analytics)($|\..+)))
+(.*\.|^)((think)?with)?google($|\..+|(adservices|apis|mail|static|syndication|tagmanager|tagservices|usercontent|zip|-analytics)($|\..+))
 (.*\.|^)g(gpht|mail|static|v(t[12])?)($|\..+)
 (.*\.|^)chrom(e(experiments)?|ium)($|\..+)
 (.*\.|^)ampproject($|\..+)


### PR DESCRIPTION
Pattern 1 in `regex.list` failed to match `google.com`, `www.google.com`, `mail.google.com`, `google.co.uk`, `withgoogle.com`, and `thinkwithgoogle.com`. It only matched bare `google` (no TLD) or compound forms like `googleapis.com` and `googlemail.com`.

The root cause was the pattern tail: `($|((suffix)($|\..+)))` which requires either end-of-string OR one of the listed suffixes — with no fallback for a plain TLD like `.com`.

## Fix

Changed the tail from:
```
($|((suffix)($|\..+)))
```
to:
```
($|\..+|(suffix)($|\..+))
```

This is now consistent with patterns 2–9 in the file, which all correctly use `($|\..+)` to match any TLD.

> Note: `google.com` was still blocked in practice via the flat domain lists, so there was no user-facing impact.

Closes #228